### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/hmpps-remand-and-sentencing/Chart.yaml
+++ b/helm_deploy/hmpps-remand-and-sentencing/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-remand-and-sentencing
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-remand-and-sentencing/values.yaml
+++ b/helm_deploy/hmpps-remand-and-sentencing/values.yaml
@@ -1,18 +1,17 @@
----
 generic-service:
   nameOverride: hmpps-remand-and-sentencing
-  productId: "UNASSIGNED"   # productId for the product that this belongs too, i.e. DPS001, see README.md for details
+  productId: "UNASSIGNED" # productId for the product that this belongs too, i.e. DPS001, see README.md for details
 
   replicaCount: 4
 
   image:
     repository: quay.io/hmpps/hmpps-remand-and-sentencing
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-remand-and-sentencing-cert
 
   livenessProbe:
@@ -54,59 +53,15 @@ generic-service:
       REDIS_AUTH_TOKEN: "auth_token"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    moj-global-protect: "35.176.93.186/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    quantum: "62.25.109.197/32"
-    quantum_alt: "212.137.36.230/32"
-    digitalprisons1: "52.56.112.98/32"
-    digitalprisons2: "52.56.118.154/32"
-    j5-phones-1: "35.177.125.252/32"
-    j5-phones-2: "35.177.137.160/32"
-    sodexo-bronzefield: "51.148.9.201/32"
-    sodexo-northumberland: "88.98.48.10/32"
-    sodexo-northumberland2: "51.148.47.137/32"
-    sodoxeo-forest-bank: "51.155.85.249/32"
-    sodexo-peterborough: "51.155.55.241/32"
-    serco: "217.22.14.0/24"
-    durham-tees-valley: "51.179.197.1/32"
-    oakwood-01: "217.161.76.184/29"
-    oakwood-02: "217.161.76.192/29"
-    oakwood-1: "217.161.76.187/32"
-    oakwood-2: "217.161.76.195/32"
-    oakwood-3: "217.161.76.186/32"
-    oakwood-4: "217.161.76.194/32"
-    dxc-mitcheldean: "195.92.38.16/28"
-    ark-dom1-ttp1: "195.59.75.0/24"
-    ark-dom1-farnborough: "194.33.192.0/24"
-    ark-dom1-farnborough-psn: "51.247.3.0/24"
-    ark-dom1-corsham: "194.33.196.0/24"
-    ark-dom1-corsham-psn: "51.247.4.0/24"
-    ark-dom1-non-live-1: "194.33.193.0/25"
-    ark-dom1-non-live-2: "194.33.197.0/25"
-    moj-official-ark-c-expo-e: "51.149.249.0/29"
-    moj-official-ark-c-vodafone: "194.33.248.0/29"
-    moj-official-ark-f-vodafone: "194.33.249.0/29"
-    moj-official-ark-f-expo-e: "51.149.249.32/29"
-    interservfls: "51.179.196.131/32"
-    sodexo1: "80.86.46.16/32"
-    sodexo2: "80.86.46.17/32"
-    sodexo3: "80.86.46.18/32"
-    dxc_webproxy1: "195.92.38.20/32"
-    dxc_webproxy2: "195.92.38.21/32"
-    dxc_webproxy3: "195.92.38.22/32"
-    dxc_webprox23: "195.92.38.23/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    moj-official-tgw-preprod: "51.149.251.0/24"
-    crc-rrp: "62.253.83.37/32"
-    crc-pp-wwm: "5.153.255.210/32"
-    cymulate-1: "54.217.50.18/32"
-    cymulate-2: "52.208.202.111/32"
-    cymulate-3: "52.49.144.209/32"
+    ark-dom1-farnborough: 194.33.192.0/24
+    ark-dom1-corsham: 194.33.196.0/24
+    cymulate-1: 54.217.50.18/32
+    cymulate-2: 52.208.202.111/32
+    cymulate-3: 52.49.144.209/32
+    groups:
+      - internal
+      - prisons
+      - private_prisons
 
 generic-prometheus-alerts:
   targetApplication: hmpps-remand-and-sentencing


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-remand-and-sentencing/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons,private_prisons`
- The size of the allowlist defined in this file will change: `53 => 5 (48 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi
  

- ark-nps-hmcts-ttp2
  

- ark-nps-hmcts-ttp4
  

- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

- fivewells-3
  

- fivewells-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

- quantum
  

- quantum_alt
  

- digitalprisons1
  

- digitalprisons2
  

- j5-phones-1
  

- j5-phones-2
  

- durham-tees-valley
  

- quantum3
  

- ark-dom1-psn2
  

- ark-dom1-psn1
  

- interservfls
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  

- crc-rrp
  

- crc-pp-wwm
  
