### PR TITLE
Change default ingress url to match that defineed by the callback URL 's defined in the dev auth service - so the we can run the UI locally against dev services

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -172,7 +172,7 @@ export default {
   adjustmentService: {
     ui_url: get('ADJUSTMENTS_UI_URL', 'http://127.0.0.1:3000/adjustments', requiredInProduction),
   },
-  domain: get('INGRESS_URL', 'http://127.0.0.1:3000', requiredInProduction),
+  domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   sqs: {
     audit: auditConfig(),
   },


### PR DESCRIPTION
It's quite easy just to run and test the service via the cypress tests

just as a nice to have, this would allow to run locally against the dev data