### PR TITLE
Initial commit of the Remand and Sentencing > Legacy Sentence Types screens

### DIFF
--- a/assets/js/autoCompleteLegacySentenceType.js
+++ b/assets/js/autoCompleteLegacySentenceType.js
@@ -1,0 +1,16 @@
+window.addEventListener('load', function () {
+  accessibleAutocomplete.enhanceSelectElement({
+    selectElement: document.querySelector('#legacy-sentence-type-lookup'),
+    showAllValues: true,
+    defaultValue: '',
+    placeholder: 'Start typing…',
+    autoselect: true,
+    confirmOnBlur: false,
+    onConfirm: function (selected) {
+      const value = document.querySelector('#legacy-sentence-type-lookup').value
+      if (value) {
+        window.location.href = `/sentence-types/legacy/detail?nomisSentenceTypeReference=${encodeURIComponent(value)}`
+      }
+    },
+  })
+})

--- a/assets/js/showLegacySentenceTypeFilters.js
+++ b/assets/js/showLegacySentenceTypeFilters.js
@@ -1,0 +1,11 @@
+const toggleButton = document.getElementById('toggle-filters-button')
+const panel = document.getElementById('filters-panel')
+
+if (toggleButton && panel) {
+  toggleButton.addEventListener('click', function () {
+    const isOpen = panel.hasAttribute('hidden') === false
+    panel.hidden = isOpen
+    toggleButton.setAttribute('aria-expanded', !isOpen)
+    toggleButton.innerText = isOpen ? 'Show filters' : 'Hide filters'
+  })
+}

--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -1,6 +1,6 @@
 .govuk-main-wrapper {
   min-height: 600px;
-  padding-top: 0px;
+  padding-top: 0;
 }
 
 .no-bottom-border {
@@ -25,4 +25,8 @@
 
 .govuk-button--link:hover {
   background: #144e81
+}
+
+.govuk-border--1px {
+  border:1px solid #b1b4b6
 }

--- a/server/@types/remandAndSentencingApi/index.d.ts
+++ b/server/@types/remandAndSentencingApi/index.d.ts
@@ -604,6 +604,86 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/legacy/sentence-type/summary': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get historic NOMIS sentence type by nomis sentence type reference
+     * @description Returns historic NOMIS sentence type information for the specified type in a summary format
+     */
+    get: operations['getLegacySentenceTypeSummary']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/legacy/sentence-type/all': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get all historic NOMIS sentence types
+     * @description Returns a set of historic NOMIS sentence type information in a detailed format
+     */
+    get: operations['getLegacyAllSentenceTypes']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/legacy/sentence-type/all/summary': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get summary of all historic NOMIS sentence types
+     * @description Returns a set of historic NOMIS sentence type information in a summary format
+     */
+    get: operations['getLegacyAllSentenceTypesSummaries']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/legacy/sentence-type/': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get historic NOMIS sentence type by nomis sentence type reference
+     * @description Returns historic NOMIS sentence type information for the specified type in a detailed format
+     */
+    get: operations['getLegacySentenceType']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/legacy/court-case/{courtCaseUuid}/test': {
     parameters: {
       query?: never
@@ -652,8 +732,8 @@ export interface paths {
       cookie?: never
     }
     /**
-     * Retrieve all court cases for person
-     * @description This endpoint will retrieve all court cases for a person
+     * Retrieve all court cases for person (that have appearances)
+     * @description This endpoint will retrieve all court cases (that have appearances) for a person
      */
     get: operations['searchCourtCases']
     put?: never
@@ -825,7 +905,9 @@ export interface paths {
     trace?: never
   }
 }
+
 export type webhooks = Record<string, never>
+
 export interface components {
   schemas: {
     CreateRecall: {
@@ -902,7 +984,7 @@ export interface components {
       outcomeDescription?: string
       /** Format: date-time */
       nextEventDateTime?: string
-      /** @example 14:17:35.95498 */
+      /** @example 14:30:00 */
       appearanceTime?: string
       outcomeDispositionCode?: string
       outcomeConvictionFlag?: boolean
@@ -995,7 +1077,7 @@ export interface components {
     CreateNextCourtAppearance: {
       /** Format: date */
       appearanceDate: string
-      /** @example 14:17:35.95498 */
+      /** @example 14:30:00 */
       appearanceTime?: string
       courtCode: string
       /** Format: uuid */
@@ -1268,6 +1350,7 @@ export interface components {
         | 'LEGACY'
         | 'NON_CUSTODIAL'
         | 'LEGACY_RECALL'
+        | 'UNKNOWN'
       hintText?: string
       /** Format: int32 */
       displayOrder: number
@@ -1334,6 +1417,88 @@ export interface components {
       /** Format: date */
       sentenceStartDate: string
     }
+    LegacySentenceTypeGroupingSummary: {
+      nomisSentenceTypeReference: string
+      nomisDescription: string
+      isIndeterminate: boolean
+      recall: components['schemas']['RecallType']
+      nomisActive: boolean
+      /** Format: date */
+      nomisExpiryDate?: string
+    }
+    RecallType: {
+      isRecall: boolean
+      type: string
+      isFixedTermRecall: boolean
+      /** Format: int32 */
+      lengthInDays: number
+    }
+    LegacySentenceType: {
+      nomisSentenceTypeReference: string
+      /** @enum {string} */
+      classification:
+        | 'STANDARD'
+        | 'EXTENDED'
+        | 'SOPC'
+        | 'INDETERMINATE'
+        | 'BOTUS'
+        | 'CIVIL'
+        | 'DTO'
+        | 'FINE'
+        | 'LEGACY'
+        | 'NON_CUSTODIAL'
+        | 'LEGACY_RECALL'
+        | 'UNKNOWN'
+      classificationPeriodDefinition?: components['schemas']['SentenceTypePeriodDefinitions']
+      /** Format: int32 */
+      sentencingAct: number
+      eligibility?: components['schemas']['SentenceEligibility']
+      recallType: components['schemas']['RecallType']
+      inputSentenceType?: components['schemas']['SentenceType']
+      nomisActive: boolean
+      nomisDescription: string
+      /** Format: date */
+      nomisExpiryDate?: string
+      nomisTermTypes: {
+        [key: string]: string
+      }
+    }
+    Period: {
+      /** @enum {string} */
+      type:
+        | 'SENTENCE_LENGTH'
+        | 'CUSTODIAL_TERM'
+        | 'LICENCE_PERIOD'
+        | 'TARIFF_LENGTH'
+        | 'TERM_LENGTH'
+        | 'OVERALL_SENTENCE_LENGTH'
+        | 'UNSUPPORTED'
+      auto: boolean
+      periodLength?: components['schemas']['PeriodLengthDetail']
+    }
+    PeriodLengthDetail: {
+      years: string
+      periodOrder: string[]
+      /** @enum {string} */
+      periodLengthType:
+        | 'SENTENCE_LENGTH'
+        | 'CUSTODIAL_TERM'
+        | 'LICENCE_PERIOD'
+        | 'TARIFF_LENGTH'
+        | 'TERM_LENGTH'
+        | 'OVERALL_SENTENCE_LENGTH'
+        | 'UNSUPPORTED'
+      description: string
+    }
+    SentenceEligibility: {
+      /** @enum {string} */
+      toreraEligibilityType?: 'NONE' | 'SOPC' | 'SDS'
+      /** @enum {string} */
+      sdsPlusEligibilityType?: 'NONE' | 'SECTION250' | 'SDS'
+    }
+    SentenceTypePeriodDefinitions: {
+      periodDefinitions: components['schemas']['Period'][]
+    }
     LegacyCourtCase: {
       courtCaseUuid: string
       prisonerId: string
@@ -1366,7 +1531,7 @@ export interface components {
       courtCode: string
       /** Format: date */
       appearanceDate: string
-      /** @example 14:17:35.95498 */
+      /** @example 14:30:00 */
       appearanceTime: string
       charges: components['schemas']['LegacyCharge'][]
       nextCourtAppearance?: components['schemas']['LegacyNextCourtAppearance']
@@ -1374,7 +1539,7 @@ export interface components {
     LegacyNextCourtAppearance: {
       /** Format: date */
       appearanceDate: string
-      /** @example 14:17:35.95498 */
+      /** @example 14:30:00 */
       appearanceTime?: string
       courtId: string
     }
@@ -1468,7 +1633,7 @@ export interface components {
     NextCourtAppearance: {
       /** Format: date */
       appearanceDate: string
-      /** @example 14:17:35.95498 */
+      /** @example 14:30:00 */
       appearanceTime?: string
       courtCode: string
       appearanceType: components['schemas']['AppearanceType']
@@ -1481,32 +1646,32 @@ export interface components {
       sort?: string[]
     }
     PageCourtCase: {
-      /** Format: int32 */
-      totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      sort?: components['schemas']['SortObject']
       /** Format: int32 */
-      size?: number
+      totalPages?: number
       first?: boolean
       last?: boolean
+      /** Format: int32 */
+      size?: number
       content?: components['schemas']['CourtCase'][]
       /** Format: int32 */
       number?: number
-      pageable?: components['schemas']['PageableObject']
+      sort?: components['schemas']['SortObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     PageableObject: {
-      sort?: components['schemas']['SortObject']
       /** Format: int64 */
       offset?: number
+      sort?: components['schemas']['SortObject']
+      /** Format: int32 */
+      pageSize?: number
       paged?: boolean
       /** Format: int32 */
       pageNumber?: number
-      /** Format: int32 */
-      pageSize?: number
       unpaged?: boolean
     }
     SortObject: {
@@ -1521,7 +1686,9 @@ export interface components {
   headers: never
   pathItems: never
 }
+
 export type $defs = Record<string, never>
+
 export interface operations {
   getRecall: {
     parameters: {
@@ -3269,6 +3436,198 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['PersonDetails']
+        }
+      }
+    }
+  }
+  getLegacySentenceTypeSummary: {
+    parameters: {
+      query: {
+        nomisSentenceTypeReference: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returns historic NOMIS sentence type */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceTypeGroupingSummary']
+        }
+      }
+      /** @description Unauthorised, requires a valid OAuth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceTypeGroupingSummary']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceTypeGroupingSummary']
+        }
+      }
+      /** @description Not found if no sentence type at given NOMIS type */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceTypeGroupingSummary']
+        }
+      }
+    }
+  }
+  getLegacyAllSentenceTypes: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returns historic NOMIS sentence type */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceType'][]
+        }
+      }
+      /** @description Unauthorised, requires a valid OAuth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceType'][]
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceType'][]
+        }
+      }
+      /** @description Not found if no sentence type at given NOMIS type */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceType'][]
+        }
+      }
+    }
+  }
+  getLegacyAllSentenceTypesSummaries: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returns historic NOMIS sentence type */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceTypeGroupingSummary'][]
+        }
+      }
+      /** @description Unauthorised, requires a valid OAuth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceTypeGroupingSummary'][]
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceTypeGroupingSummary'][]
+        }
+      }
+      /** @description Not found if no sentence type at given NOMIS type */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceTypeGroupingSummary'][]
+        }
+      }
+    }
+  }
+  getLegacySentenceType: {
+    parameters: {
+      query: {
+        nomisSentenceTypeReference: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returns historic NOMIS sentence type */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceType'][]
+        }
+      }
+      /** @description Unauthorised, requires a valid OAuth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceType'][]
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceType'][]
+        }
+      }
+      /** @description Not found if no sentence type at given NOMIS type */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LegacySentenceType'][]
         }
       }
     }

--- a/server/@types/remandAndSentencingApi/remandAndSentencingClientTypes.ts
+++ b/server/@types/remandAndSentencingApi/remandAndSentencingClientTypes.ts
@@ -54,4 +54,8 @@ export type PeriodLengthLegacyData = components['schemas']['PeriodLengthLegacyDa
 
 export type CourtAppearanceLegacyData = components['schemas']['CourtAppearanceLegacyData']
 
-export type SentenceLegacyData = components['schemas']['SentenceLegacyData']
+export type LegacySentenceType = components['schemas']['LegacySentenceType']
+
+export type LegacySentenceTypeGroupingSummary = components['schemas']['LegacySentenceTypeGroupingSummary']
+
+export type RecallType = components['schemas']['RecallType']

--- a/server/api/remandAndSentencingApiClient.ts
+++ b/server/api/remandAndSentencingApiClient.ts
@@ -10,6 +10,8 @@ import {
   DraftCourtCaseCreatedResponse,
   DraftCreateCourtAppearance,
   DraftCreateCourtCase,
+  LegacySentenceType,
+  LegacySentenceTypeGroupingSummary,
   OffenceOutcome,
   PageCourtCase,
   PageCourtCaseAppearance,
@@ -195,5 +197,33 @@ export default class RemandAndSentencingApiClient {
     return (await this.restClient.get({
       path: `/appearance-type/${appearanceTypeUuid}`,
     })) as unknown as Promise<AppearanceType>
+  }
+
+  async getLegacySentenceTypesSummaryAll(): Promise<LegacySentenceTypeGroupingSummary[]> {
+    return (await this.restClient.get({
+      path: `/legacy/sentence-type/all/summary`,
+    })) as unknown as Promise<LegacySentenceTypeGroupingSummary[]>
+  }
+
+  async getLegacySentenceTypesAll(): Promise<LegacySentenceType[]> {
+    return (await this.restClient.get({
+      path: `/legacy/sentence-type/all`,
+    })) as unknown as Promise<LegacySentenceType[]>
+  }
+
+  async getLegacySentenceTypesDetail(nomisSentenceTypeReference: string) {
+    const encodedReference = encodeURIComponent(nomisSentenceTypeReference)
+
+    return (await this.restClient.get({
+      path: `/legacy/sentence-type/?nomisSentenceTypeReference=${encodedReference}`,
+    })) as unknown as Promise<LegacySentenceType[]>
+  }
+
+  async getLegacySentenceTypesSummary(nomisSentenceTypeReference: string) {
+    const encodedReference = encodeURIComponent(nomisSentenceTypeReference)
+
+    return (await this.restClient.get({
+      path: `/legacy/sentence-type/summary/?nomisSentenceTypeReference=${encodedReference}`,
+    })) as unknown as Promise<LegacySentenceTypeGroupingSummary>
   }
 }

--- a/server/routes/handlers/sentenceTypesRoutes.ts
+++ b/server/routes/handlers/sentenceTypesRoutes.ts
@@ -1,0 +1,118 @@
+import type { Request, Response } from 'express'
+import type RemandAndSentencingService from '../../services/remandAndSentencingService'
+import { RecallType } from '../../@types/remandAndSentencingApi/remandAndSentencingClientTypes'
+
+export default class SentenceTypesRoutesHandler {
+  constructor(private readonly remandAndSentencingService: RemandAndSentencingService) {}
+
+  index = async (req: Request, res: Response) => {
+    const legacySentenceTypes = await this.remandAndSentencingService.getLegacySentenceTypesSummaryAll(
+      req.user.username,
+    )
+
+    const legacySentenceTypeItems = [
+      { value: '', text: 'Lookup a legacy sentence type' },
+      ...legacySentenceTypes.map(sentence => ({
+        value: sentence.nomisSentenceTypeReference,
+        text: sentence.nomisSentenceTypeReference?.trim(),
+      })),
+    ]
+
+    res.render('pages/sentenceTypes/index', {
+      legacySentenceTypeItems,
+    })
+  }
+
+  getLegacySentenceTypes = async (req: Request, res: Response) => {
+    let filtered = await this.remandAndSentencingService.getLegacySentenceTypesSummaryAll(req.user.username)
+
+    const { active, indeterminate, recall } = req.query
+
+    if (active === 'true') {
+      filtered = filtered.filter(s => s.nomisActive === true)
+    } else if (active === 'false') {
+      filtered = filtered.filter(s => s.nomisActive === false)
+    }
+
+    if (indeterminate === 'true') {
+      filtered = filtered.filter(s => s.isIndeterminate === true)
+    } else if (indeterminate === 'false') {
+      filtered = filtered.filter(s => s.isIndeterminate === false)
+    }
+
+    if (recall) {
+      const recallStr = recall.toString()
+
+      if (recallStr === 'FIXED_TERM_RECALL') {
+        const fixedTermRecalls = ['FIXED_TERM_RECALL_14', 'FIXED_TERM_RECALL_28']
+        filtered = filtered.filter(s => s.recall && fixedTermRecalls.includes(s.recall.type))
+      } else {
+        filtered = filtered.filter(s => s.recall?.type === recallStr)
+      }
+    }
+
+    const selectItem = (value: string, text: string, selectedValue?: string) => ({
+      value,
+      text,
+      selected: selectedValue === value,
+    })
+
+    const activeFilterItems = [
+      selectItem('', 'All', active as string),
+      selectItem('true', 'Active only', active as string),
+      selectItem('false', 'Inactive only', active as string),
+    ]
+
+    const indeterminateFilterItems = [
+      selectItem('', 'All', indeterminate as string),
+      selectItem('true', 'Yes', indeterminate as string),
+      selectItem('false', 'No', indeterminate as string),
+    ]
+
+    const recallFilterItems = [
+      selectItem('', 'All', recall as string),
+      selectItem('NONE', 'No recall', recall as string),
+      selectItem('FIXED_TERM_RECALL', 'Fixed term recall (14 or 28 day)', recall as string),
+      selectItem('STANDARD_RECALL', 'Standard recall', recall as string),
+      selectItem('STANDARD_RECALL_255', 'Standard recall (Section 255)', recall as string),
+    ]
+
+    const formatRecallName = (recallType: RecallType): string => {
+      if (recallType.isFixedTermRecall && recallType.lengthInDays) {
+        return `Fixed term recall (${recallType.lengthInDays} days)`
+      }
+
+      return recallType.type.replace(/_/g, ' ')
+    }
+
+    const legacySentenceTypes = filtered.map(s => ({
+      ...s,
+
+      formattedRecallName: formatRecallName(s.recall),
+    }))
+
+    res.render('pages/sentenceTypes/legacy', {
+      legacySentenceTypes,
+      activeFilterItems,
+      indeterminateFilterItems,
+      recallFilterItems,
+      query: req.query,
+    })
+  }
+
+  getLegacySentenceTypeDetail = async (req: Request, res: Response) => {
+    const nomisSentenceTypeReference = req.query.nomisSentenceTypeReference?.toString()
+    if (!nomisSentenceTypeReference) {
+      return res.status(400).send('Missing nomisSentenceTypeReference')
+    }
+    const legacySentenceType = await this.remandAndSentencingService.getLegacySentenceType(
+      nomisSentenceTypeReference,
+      req.user.username,
+    )
+
+    return res.render('pages/sentenceTypes/detail', {
+      legacySentenceType,
+      nomisSentenceTypeReference,
+    })
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,6 +7,7 @@ import ApiRoutes from './apiRoutes'
 import OffenceRoutes from './offenceRoutes'
 import type { Services } from '../services'
 import { Page } from '../services/auditService'
+import sentenceTypeRoutes from './sentenceTypesRoutes'
 
 const upload = multer({ dest: 'uploads/' })
 export default function routes(services: Services): Router {
@@ -18,6 +19,8 @@ export default function routes(services: Services): Router {
 
   const postWithFileUpload = (path: string | string[], handler: RequestHandler) =>
     router.post(path, upload.single('warrantUpload'), asyncMiddleware(handler))
+
+  router.use('/sentence-types', sentenceTypeRoutes(services))
 
   const courtCaseRoutes = new CourtCaseRoutes(
     services.courtAppearanceService,

--- a/server/routes/sentenceTypesRoutes.ts
+++ b/server/routes/sentenceTypesRoutes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express'
+import SentenceTypesRoutes from './handlers/sentenceTypesRoutes'
+import type { Services } from '../services'
+
+export default function sentenceTypeRoutes(services: Services): Router {
+  const router = Router()
+  const routes = new SentenceTypesRoutes(services.remandAndSentencingService)
+
+  router.get('/', routes.index)
+
+  router.get('/legacy', routes.getLegacySentenceTypes)
+
+  router.get('/legacy/detail', routes.getLegacySentenceTypeDetail)
+
+  return router
+}

--- a/server/services/remandAndSentencingService.ts
+++ b/server/services/remandAndSentencingService.ts
@@ -1,12 +1,14 @@
 import type { CourtAppearance, CourtCase } from 'models'
 import { Dayjs } from 'dayjs'
-import type {
+import {
   AppearanceType,
   CreateCourtAppearanceResponse,
   CreateCourtCaseResponse,
   DraftCourtAppearance,
   DraftCourtAppearanceCreatedResponse,
   DraftCourtCaseCreatedResponse,
+  LegacySentenceType,
+  LegacySentenceTypeGroupingSummary,
   PageCourtCase,
   PageCourtCaseAppearance,
   PageCourtCaseContent,
@@ -160,6 +162,18 @@ export default class RemandAndSentencingService {
   async getAppearanceTypeByUuid(appearanceTypeUuid: string, username: string): Promise<AppearanceType> {
     return new RemandAndSentencingApiClient(await this.getSystemClientToken(username)).getAppearanceTypeByUuid(
       appearanceTypeUuid,
+    )
+  }
+
+  async getLegacySentenceTypesSummaryAll(username: string): Promise<LegacySentenceTypeGroupingSummary[]> {
+    return new RemandAndSentencingApiClient(
+      await this.getSystemClientToken(username),
+    ).getLegacySentenceTypesSummaryAll()
+  }
+
+  async getLegacySentenceType(nomisSentenceTypeReference: string, username: string): Promise<LegacySentenceType[]> {
+    return new RemandAndSentencingApiClient(await this.getSystemClientToken(username)).getLegacySentenceTypesDetail(
+      nomisSentenceTypeReference,
     )
   }
 

--- a/server/views/pages/sentenceTypes/detail.njk
+++ b/server/views/pages/sentenceTypes/detail.njk
@@ -1,0 +1,64 @@
+{% extends "../../partials/layout.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+
+{% set pageTitle = (legacySentenceType[0].nomisSentenceTypeReference ~ " – " ~ applicationName ~ " – Sentence type detail") if legacySentenceType and legacySentenceType.length > 0 else (applicationName ~ " – Sentence type detail") %}
+
+
+{% block content %}
+
+    {{ govukBreadcrumbs({
+        items: [
+            {
+                text: "Remand and Sentencing",
+                href: "/"
+            },
+            {
+                text: "Sentence Types",
+                href: "/sentence-types/"
+            },
+            {
+                text: "Legacy",
+                href: "/sentence-types/legacy/"
+            },
+            {
+                text: "Detail",
+                href: "/sentence-types/legacy/detail?nomisSentenceTypeReference=" + nomisSentenceTypeReference
+            }
+        ]
+    }) }}
+    <h1 class="govuk-heading-l govuk-!-padding-top-9">{{ legacySentenceType[0].nomisSentenceTypeReference }}  - Legacy sentence type details</h1>
+
+    <p class="govuk-body">
+        The information on this page relates to the sentence type as recorded in NOMIS. Some fields may vary depending on the sentencing Act under which the sentence was imposed.
+    </p>
+
+    {% if legacySentenceType | length > 0 %}
+
+        <div class="govuk-tabs" data-module="govuk-tabs">
+            <h2 class="govuk-tabs__title">Contents</h2>
+
+            <ul class="govuk-tabs__list">
+                {% for sentenceType in legacySentenceType %}
+
+                    <li class="govuk-tabs__list-item {% if loop.first %}govuk-tabs__list-item--selected{% endif %}">
+                        <a class="govuk-tabs__tab" href="#tab-{{ sentenceType.sentencingAct | string | lower | replace(" ", "-") | replace("/", "-") }}">
+                            {{ sentenceType.sentencingAct or "Unknown Act" }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+
+            {% for sentenceType in legacySentenceType %}
+                <div class="govuk-tabs__panel {% if not loop.first %}govuk-tabs__panel--hidden{% endif %}" id="tab-{{ sentenceType.sentencingAct | string | lower | replace(" ", "-") | replace("/", "-") }}">
+                    {% include "partials/legacy-sentence-type-panel.njk" %}
+                </div>
+            {% endfor %}
+        </div>
+   {% endif %}
+
+    <a href="/sentence-types/legacy" class="govuk-back-link govuk-!-margin-top-7">Back to legacy sentence types</a>
+
+{% endblock %}
+
+

--- a/server/views/pages/sentenceTypes/index.njk
+++ b/server/views/pages/sentenceTypes/index.njk
@@ -1,0 +1,54 @@
+{% extends "../../partials/layout.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitle = applicationName + " – Sentence types" %}
+
+{% block content %}
+    {{ govukBreadcrumbs({
+        items: [
+            { text: "Remand and Sentencing Administration", href: "/" },
+            { text: "Sentence Types", href: "/sentence-types/" }
+        ]
+    }) }}
+
+    <h1 class="govuk-heading-l govuk-!-padding-top-9">Sentence types</h1>
+
+    <p class="govuk-body">
+        This page helps you find and review sentence types.
+    </p>
+
+    <h2 class="govuk-heading-m">Legacy sentence types</h2>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+            <h3 class="govuk-heading-s">Find a sentence type</h3>
+            <p class="govuk-body">Start typing a legacy sentence type reference or description to go straight to its
+                detail page.</p>
+
+            {{ govukSelect({
+                id: "legacy-sentence-type-lookup",
+                name: "legacy-sentence-type-lookup",
+                label: {
+                    text: "Legacy sentence type"
+                },
+                classes: "autocomplete-select",
+                items: legacySentenceTypeItems
+            }) }}
+        </div>
+
+        <div class="govuk-grid-column-one-half">
+            <h3 class="govuk-heading-s">Browse all legacy sentence types</h3>
+            <p class="govuk-body">View and filter the full list of sentence types originally recorded in NOMIS.</p>
+            {{ govukButton({
+                text: "Browse legacy sentence types",
+                href: "/sentence-types/legacy"
+            }) }}
+        </div>
+    </div>
+{% endblock %}
+
+{% block javascripts %}
+    <script src="/assets/accessible-autocomplete.min.js"></script>
+    <script src="/assets/js/autoCompleteLegacySentenceType.js" type="module"></script>
+{% endblock %}

--- a/server/views/pages/sentenceTypes/legacy.njk
+++ b/server/views/pages/sentenceTypes/legacy.njk
@@ -1,0 +1,139 @@
+{% extends "../../partials/layout.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% set pageTitle = applicationName + " – Legacy sentence types" %}
+
+{% block content %}
+
+    {{ govukBreadcrumbs({
+        items: [
+            {
+                text: "Remand and Sentencing",
+                href: "/"
+            },
+            {
+                text: "Sentence Types",
+                href: "/sentence-types/"
+            },
+            {
+                text: "Legacy",
+                href: "/sentence-types/legacy/"
+            }]}) }}
+
+    <h1 class="govuk-heading-l govuk-!-padding-top-9">Legacy sentence types</h1>
+
+    {% if query.active or query.indeterminate or query.recall %}
+
+        <p class="govuk-body">
+            Showing sentence types
+            {% if query.active == 'true' %} that are
+                <strong>active</strong>{% elseif query.active == 'false' %} that are
+                <strong>inactive</strong>{% endif %}
+            {% if query.indeterminate == 'true' %} {% if query.active %} and{% endif %}
+                <strong>indeterminate</strong>{% elseif query.indeterminate == 'false' %} {% if query.active %} and{% endif %}
+                <strong>not indeterminate</strong>{% endif %}
+            {% if query.recall %} {% if query.active or query.indeterminate %} and{% endif %} with
+            <strong>{{ query.recall | replace("_", " ") | lower }}</strong> recall{% endif %}.
+        </p>
+    {% else %}
+        <p class="govuk-body">
+            This page lists sentence types that were originally created and maintained in NOMIS. These sentence types remain relevant for reviewing or interpreting historic legacy system (e.g. NOMIS) data.
+        </p>
+
+    {% endif %}
+
+
+    <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-3" type="button"
+            aria-controls="filters-panel" aria-expanded="false" id="toggle-filters-button">
+        Show filters
+    </button>
+
+    <div id="filters-panel" hidden class="govuk-!-padding-2 govuk-!-margin-bottom-2 govuk-border--1px">
+
+        <form method="get" class="govuk-form-group govuk-!-margin-bottom-1 govuk-!-display-inline">
+            <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                    Show only sentence types that match:
+                </legend>
+
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-one-quarter">
+                        {{ govukSelect({
+                            id: "active",
+                            name: "active",
+                            label: { text: "Active in NOMIS" },
+                            items: activeFilterItems
+                        }) }}
+                    </div>
+
+                    <div class="govuk-grid-column-one-quarter">
+
+                        {{ govukSelect({
+                            id: "indeterminate",
+                            name: "indeterminate",
+                            label: { text: "Indeterminate?" },
+                            items: indeterminateFilterItems
+                        }) }}
+                    </div>
+
+                    <div class="govuk-grid-column-one-quarter">
+                        {{ govukSelect({
+                            id: "recall",
+                            name: "recall",
+                            label: { text: "Recall type" },
+                            items: recallFilterItems
+                        }) }}
+                    </div>
+
+                    <div class="govuk-grid-column-one-quarter govuk-!-padding-top-6">
+                        <button type="submit" class="govuk-button govuk-!-margin-top-0">Apply filters</button>
+
+                        {% if query.active or query.indeterminate or query.recall %}
+                        <a href="/sentence-types/legacy" class="govuk-button govuk-button--secondary govuk-!-margin-top-0">Clear filters</a>
+                        {%  endif %}
+                    </div>
+
+                </div>
+            </fieldset>
+
+        </form>
+    </div>
+
+
+
+    <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-visually-hidden">List of legacy sentence types</caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">NOMIS reference</th>
+            <th scope="col" class="govuk-table__header">Description</th>
+            <th scope="col" class="govuk-table__header">Indeterminate?</th>
+            <th scope="col" class="govuk-table__header">Recall type</th>
+            <th scope="col" class="govuk-table__header">Details</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        {% for sentence in legacySentenceTypes %}
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ sentence.nomisSentenceTypeReference }}</td>
+                <td class="govuk-table__cell">{{ sentence.nomisDescription }}</td>
+                <td class="govuk-table__cell">{% if sentence.isIndeterminate %} Yes
+                    {% else %} No
+                    {% endif %}</td>
+                <td class="govuk-table__cell">{{ sentence.formattedRecallName }}</td>
+
+                <td class="govuk-table__cell">
+                    <a href="/sentence-types/legacy/detail?nomisSentenceTypeReference={{ sentence.nomisSentenceTypeReference | urlencode }}"
+                       class="govuk-link">View details</a>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+
+{% endblock %}
+
+{% block javascripts %}
+    <script id="autocomplete-script" src="/assets/js/showLegacySentenceTypeFilters.js"></script>
+{% endblock %}

--- a/server/views/pages/sentenceTypes/legacy.njk
+++ b/server/views/pages/sentenceTypes/legacy.njk
@@ -118,7 +118,7 @@
             <tr class="govuk-table__row">
                 <td class="govuk-table__cell">{{ sentence.nomisSentenceTypeReference }}</td>
                 <td class="govuk-table__cell">{{ sentence.nomisDescription }}</td>
-                <td class="govuk-table__cell">{% if sentence.isIndeterminate %} Yes
+                <td class="govuk-table__cell"> {{"Yes" if sentence.isIndeterminate else "No"}}
                     {% else %} No
                     {% endif %}</td>
                 <td class="govuk-table__cell">{{ sentence.formattedRecallName }}</td>

--- a/server/views/partials/legacy-sentence-type-panel.njk
+++ b/server/views/partials/legacy-sentence-type-panel.njk
@@ -51,7 +51,7 @@
             {% endif %}
         </div>
     {% endif %}
-    <p class="govuk-body"><strong>Active in NOMIS:</strong> {% if sentenceType.nomisActive %}Yes{% else %}No{% endif %}
+    <p class="govuk-body"><strong>Active in NOMIS:</strong>{{"Yes" if sentenceType.nomisActive else "No" }}
     </p>
 
     {% if sentenceType.nomisExpiryDate %}
@@ -90,7 +90,7 @@
                     <p class="govuk-body"><strong>Length:</strong> {{ period.periodLength.years }} years</p>
                 {% endif %}
 
-                <p class="govuk-body"><strong>Auto-calculated:</strong> {% if period.auto %}Yes{% else %}No{% endif %}
+                <p class="govuk-body"><strong>Auto-calculated:</strong>{{"Yes" if period.auto else "No"  }}
                 </p>
             </div>
         {% endfor %}

--- a/server/views/partials/legacy-sentence-type-panel.njk
+++ b/server/views/partials/legacy-sentence-type-panel.njk
@@ -1,0 +1,98 @@
+{%- from "moj/components/alert/macro.njk" import mojAlert -%}
+
+<div class="govuk-!-margin-bottom-9">
+    {% if not sentenceType.nomisActive %}
+        {{ mojAlert({
+            variant: "warning",
+            title: "Inactive Sentence Type",
+            showTitleAsHeading: true,
+            dismissible: false,
+            html: 'This sentence type is no longer active in NOMIS.'
+        }) }}
+    {% endif %}
+
+    <h3 class="govuk-heading-m"><strong>NOMIS reference:</strong> {{ sentenceType.nomisSentenceTypeReference }}</h3>
+
+    <p class="govuk-body"><strong>Sentencing Act</strong>: {{ sentenceType.sentencingAct }}</p>
+    <p class="govuk-body"><strong>Description:</strong> {{ sentenceType.nomisDescription }}</p>
+    <p class="govuk-body"><strong>Classification:</strong> {{ sentenceType.classification | replace("_", " ") }}</p>
+    <p class="govuk-body"><strong>Recall type:</strong>
+        {% if sentenceType.recallType and sentenceType.recallType.name %}
+            {{ sentenceType.recallType.name | replace("_", " ") }}
+        {% else %}
+            Not specified
+        {% endif %}
+    </p>
+
+    {% if sentenceType.recallType and sentenceType.recallType.name %}
+        <div class="govuk-inset-text">
+            {% if sentenceType.recallType.isFixedTermRecall %}
+                This is a <strong>fixed term
+                recall</strong>, where a set number of days is applied. The standard length is
+                {{ sentenceType.recallType.lengthInDays or "not specified" }} days.
+            {% else %}
+                {% if sentenceType.recallType.name == "STANDARD_RECALL" %}
+                    This is a <strong>standard
+                    recall</strong>, where the release is determined by the Parole Board rather than a fixed period.
+                    {% elif sentenceType.recallType.name == "STANDARD_RECALL_255" %}
+                    This is a <strong>standard recall under section 255A of the Criminal Justice Act
+                    2003</strong>, typically used when:
+                    <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-2">
+                        <li>the person has failed to comply with the curfew condition included in their licence, or</li>
+                        <li>their whereabouts can no longer be electronically monitored at the specified curfew
+                            address.
+                        </li>
+                    </ul>
+                    {% elif sentenceType.recallType.name == "NONE" %}
+                    This sentence is not associated with a recall.
+                {% else %}
+                    This recall type is unknown.
+                {% endif %}
+            {% endif %}
+        </div>
+    {% endif %}
+    <p class="govuk-body"><strong>Active in NOMIS:</strong> {% if sentenceType.nomisActive %}Yes{% else %}No{% endif %}
+    </p>
+
+    {% if sentenceType.nomisExpiryDate %}
+        <p class="govuk-body"><strong>Expiry date:</strong> {{ sentenceType.nomisExpiryDate }}</p>
+    {% endif %}
+
+    {% if sentenceType.eligibility %}
+        <h3 class="govuk-heading-s govuk-!-margin-top-5">Eligibility</h3>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>SDS+: {{ sentenceType.eligibility.sdsPlusEligibilityType or "Not specified" }}</li>
+            <li>TORERA: {{ sentenceType.eligibility.toreraEligibilityType or "Not specified" }}</li>
+        </ul>
+    {% endif %}
+
+    <h3 class="govuk-heading-s govuk-!-margin-top-5">Term types in NOMIS</h3>
+    <ul class="govuk-list govuk-list--bullet">
+        {% for termCode, termDesc in sentenceType.nomisTermTypes %}
+            <li>{{ termCode }} – {{ termDesc }}</li>
+        {% endfor %}
+    </ul>
+
+    {% if sentenceType.classificationPeriodDefinition %}
+
+
+
+        <h3 class="govuk-heading-s govuk-!-margin-top-5">Period definitions</h3>
+        {% for period in sentenceType.classificationPeriodDefinition.periodDefinitions %}
+            <div class="govuk-inset-text govuk-!-margin-bottom-5">
+                <p class="govuk-body"><strong>Period type:</strong> {{ period.type }}</p>
+
+                {% if period.periodLength.description %}
+                    <p class="govuk-body"><strong>Description:</strong> {{ period.periodLength.description }}</p>
+                {% endif %}
+
+                {% if period.periodLength.years %}
+                    <p class="govuk-body"><strong>Length:</strong> {{ period.periodLength.years }} years</p>
+                {% endif %}
+
+                <p class="govuk-body"><strong>Auto-calculated:</strong> {% if period.auto %}Yes{% else %}No{% endif %}
+                </p>
+            </div>
+        {% endfor %}
+    {% endif %}
+</div>


### PR DESCRIPTION
This change adds a new Sentence Type admin section to view (but not amend) Legacy Sentence Types as recorded in NOMIS. It enables:

- Browsing the list of legacy sentence types
- Filtering by status and classification
- Looking up detailed information for each sentence type

This functionality is intended for internal reference only and does not support editing or synchronisation.
