### PR TITLE
RASS-1214 bugfix for when offence details are not set in session and therefore validation for conviction-date not applied correctly

### DIFF
--- a/integration_tests/e2e/offenceConvictionDate.cy.ts
+++ b/integration_tests/e2e/offenceConvictionDate.cy.ts
@@ -3,6 +3,25 @@ import OffenceConvictionDatePage from '../pages/offenceConvictionDatePage'
 import Page from '../pages/page'
 import CourtCaseWarrantDatePage from '../pages/courtCaseWarrantDatePage'
 import OffenceOffenceDatePage from '../pages/offenceOffenceDatePage'
+import OffenceSentenceTypePage from '../pages/offenceSentenceTypePage'
+import OffencePeriodLengthPage from '../pages/offencePeriodLengthPage'
+import SentenceIsSentenceConsecutiveToPage from '../pages/sentenceIsSentenceConsecutiveToPage'
+import StartPage from '../pages/startPage'
+import CourtCaseWarrantTypePage from '../pages/courtCaseWarrantTypePage'
+import CourtCaseTaskListPage from '../pages/courtCaseTaskListPage'
+import CourtCaseReferencePage from '../pages/courtCaseReferencePage'
+import CourtCaseCourtNamePage from '../pages/courtCaseCourtNamePage'
+import CourtCaseCheckAnswersPage from '../pages/courtCaseCheckAnswersPage'
+import CourtCaseOverallSentenceLengthPage from '../pages/courtCaseOverallSentenceLengthPage'
+import CourtCaseOverallConvictionDatePage from '../pages/courtCaseOverallConvictionDatePage'
+import CourtCaseOverallCaseOutcomePage from '../pages/courtCaseOverallCaseOutcomePage'
+import CourtCaseCaseOutcomeAppliedAllPage from '../pages/courtCaseCaseOutcomeAppliedAllPage'
+import SentencingWarrantInformationCheckAnswersPage from '../pages/sentencingWarrantInformationCheckAnswersPage'
+import OffenceOffenceCodePage from '../pages/offenceOffenceCodePage'
+import OffenceOffenceCodeConfirmPage from '../pages/offenceOffenceCodeConfirmPage'
+import OffenceCountNumberPage from '../pages/offenceCountNumberPage'
+import OffenceCheckOffenceAnswersPage from '../pages/offenceCheckOffenceAnswersPage'
+import OffenceEditOffencePage from '../pages/offenceEditOffencePage'
 
 context('Add Offence Conviction Date Page', () => {
   let offenceConvictionDatePage: OffenceConvictionDatePage
@@ -127,5 +146,158 @@ context('Add Offence Conviction Date Page', () => {
         'equal',
         'There is a problem The conviction date must be after the offence start date and offence end date',
       )
+  })
+})
+
+context('Add Offence Conviction Date Page tests with a full create court appearance', () => {
+  beforeEach(() => {
+    cy.task('happyPathStubs')
+    cy.signIn()
+    cy.task('stubGetOffenceByCode', {})
+    cy.task('stubSearchCourtCases', {})
+    cy.task('stubGetOffencesByCodes', {})
+    cy.task('stubGetCourtById', {})
+    cy.task('stubGetCourtsByIds')
+    cy.task('stubGetAllChargeOutcomes')
+    cy.task('stubGetServiceDefinitions')
+    cy.task('stubGetAllAppearanceOutcomes')
+    cy.task('stubGetHasSentenceToChainTo', { beforeOrOnAppearanceDate: '2023-05-12' })
+    cy.visit('/person/A1234AB')
+    cy.task('stubGetSentenceTypesByIds', [
+      {
+        sentenceTypeUuid: '467e2fa8-fce1-41a4-8110-b378c727eed3',
+        description: 'SDS (Standard Determinate Sentence)',
+        classification: 'STANDARD',
+      },
+    ])
+    cy.task('stubGetAppearanceOutcomeById', {
+      outcomeUuid: '62412083-9892-48c9-bf01-7864af4a8b3c',
+      outcomeName: 'Imprisonment',
+      outcomeType: 'SENTENCING',
+    })
+    cy.task('stubGetChargeOutcomesByIds', [
+      {
+        outcomeUuid: '63920fee-e43a-45ff-a92d-4679f1af2527',
+        outcomeName: 'Imprisonment',
+        outcomeType: 'SENTENCING',
+      },
+    ])
+    cy.task('stubGetChargeOutcomeById', {
+      outcomeUuid: 'f17328cf-ceaa-43c2-930a-26cf74480e18',
+      outcomeName: 'Imprisonment',
+      outcomeType: 'SENTENCING',
+    })
+
+    cy.task('stubSearchSentenceTypes', {
+      convictionDate: '2023-05-11',
+      offenceDate: '2023-05-10',
+    })
+    cy.task('stubIsSentenceTypeStillValid', {})
+  })
+  it('create court appearance, enter the conviction date, check answers and re-edit again', () => {
+    const caseRef = 'T12345678'
+
+    const startPage = Page.verifyOnPage(StartPage)
+    startPage.actionListLink().click()
+
+    const courtCaseWarrantTypePage = Page.verifyOnPage(CourtCaseWarrantTypePage)
+    courtCaseWarrantTypePage.radioLabelSelector('SENTENCING').click()
+    courtCaseWarrantTypePage.continueButton().click()
+    let courtCaseTaskListPage = Page.verifyOnPageTitle(CourtCaseTaskListPage, 'Add a court case')
+    courtCaseTaskListPage.appearanceInformationLink().click()
+
+    const courtCaseReferencePage = Page.verifyOnPageTitle(CourtCaseReferencePage, 'Enter the case reference')
+    courtCaseReferencePage.input().type(caseRef)
+    courtCaseReferencePage.continueButton().click()
+    const courtCaseWarrantDatePage = Page.verifyOnPage(CourtCaseWarrantDatePage)
+    courtCaseWarrantDatePage.dayDateInput('warrantDate').type('12')
+    courtCaseWarrantDatePage.monthDateInput('warrantDate').type('5')
+    courtCaseWarrantDatePage.yearDateInput('warrantDate').type('2023')
+    courtCaseWarrantDatePage.continueButton().click()
+    const courtCaseCourtNamePage = Page.verifyOnPageTitle(CourtCaseCourtNamePage, 'What is the court name?')
+    courtCaseCourtNamePage.autoCompleteInput().type('cou')
+    courtCaseCourtNamePage.firstAutoCompleteOption().click()
+    courtCaseCourtNamePage.continueButton().click()
+
+    const courtCaseCheckAnswersPage = Page.verifyOnPage(CourtCaseCheckAnswersPage)
+    courtCaseCheckAnswersPage.continueButton().click()
+
+    courtCaseTaskListPage = Page.verifyOnPageTitle(CourtCaseTaskListPage, 'Add a court case')
+    courtCaseTaskListPage.warrantInformationLink().click()
+
+    const courtCaseOverallSentenceLengthPage = Page.verifyOnPage(CourtCaseOverallSentenceLengthPage)
+    courtCaseOverallSentenceLengthPage.radioLabelSelector('false').click()
+    courtCaseOverallSentenceLengthPage.continueButton().click()
+
+    const courtCaseOverallConvictionDatePage = Page.verifyOnPage(CourtCaseOverallConvictionDatePage)
+    courtCaseOverallConvictionDatePage.radioLabelSelector('false').click()
+    courtCaseOverallConvictionDatePage.continueButton().click()
+
+    const courtCaseOverallCaseOutcomePage = Page.verifyOnPageTitle(
+      CourtCaseOverallCaseOutcomePage,
+      'Select the overall case outcome',
+    )
+    courtCaseOverallCaseOutcomePage.radioLabelContains('Imprisonment').click()
+    courtCaseOverallCaseOutcomePage.continueButton().click()
+
+    const courtCaseCaseOutcomeAppliedAllPage = Page.verifyOnPage(CourtCaseCaseOutcomeAppliedAllPage)
+    courtCaseCaseOutcomeAppliedAllPage.radioLabelSelector('true').click()
+    courtCaseCaseOutcomeAppliedAllPage.continueButton().click()
+
+    const warrantInformationCheckAnswersPage = Page.verifyOnPage(SentencingWarrantInformationCheckAnswersPage)
+    warrantInformationCheckAnswersPage.confirmAndContinueButton().click()
+
+    courtCaseTaskListPage.offencesLink().click()
+
+    const offenceOffenceDatePage = Page.verifyOnPageTitle(
+      OffenceOffenceDatePage,
+      'Enter the offence dates for the first offence',
+    )
+    offenceOffenceDatePage.dayDateInput('offenceStartDate').type('10')
+    offenceOffenceDatePage.monthDateInput('offenceStartDate').type('5')
+    offenceOffenceDatePage.yearDateInput('offenceStartDate').type('2023')
+    offenceOffenceDatePage.continueButton().click()
+
+    const offenceOffenceCodePage = Page.verifyOnPage(OffenceOffenceCodePage)
+
+    offenceOffenceCodePage.input().type('PS90037')
+    offenceOffenceCodePage.continueButton().click()
+
+    const offenceOffenceCodeConfirmPage = Page.verifyOnPage(OffenceOffenceCodeConfirmPage)
+    offenceOffenceCodeConfirmPage.continueButton().click()
+
+    const offenceCountNumber = Page.verifyOnPage(OffenceCountNumberPage)
+    offenceCountNumber.radioLabelSelector('false').click()
+    offenceCountNumber.continueButton().click()
+
+    const offenceConvictionDatePage: OffenceConvictionDatePage = Page.verifyOnPageTitle(
+      OffenceConvictionDatePage,
+      'Enter the conviction date',
+    )
+    offenceConvictionDatePage.dayDateInput('convictionDate').clear().type('11')
+    offenceConvictionDatePage.monthDateInput('convictionDate').clear().type('05')
+    offenceConvictionDatePage.yearDateInput('convictionDate').clear().type('2023')
+    offenceConvictionDatePage.continueButton().click()
+
+    const offenceSentenceTypePage = Page.verifyOnPage(OffenceSentenceTypePage)
+    offenceSentenceTypePage.radioLabelSelector('467e2fa8-fce1-41a4-8110-b378c727eed3|STANDARD').click()
+    offenceSentenceTypePage.continueButton().click()
+
+    const offencePeriodLengthPage = Page.verifyOnPageTitle(OffencePeriodLengthPage, 'sentence length')
+    offencePeriodLengthPage.yearsInput().type('1')
+    offencePeriodLengthPage.continueButton().click()
+
+    const sentenceIsConsecutiveToPage = Page.verifyOnPage(SentenceIsSentenceConsecutiveToPage)
+    sentenceIsConsecutiveToPage.radioLabelSelector('false').click()
+    sentenceIsConsecutiveToPage.continueButton().click()
+
+    const offenceCheckOffenceAnswersPage = new OffenceCheckOffenceAnswersPage('You have added 1 offence')
+    offenceCheckOffenceAnswersPage.editOffenceLink('A1234AB', '1', '0', '0').click()
+    const offenceEditOffencePage = Page.verifyOnPageTitle(OffenceEditOffencePage, 'offence')
+    offenceEditOffencePage.editFieldLink('A1234AB', 'add', '1', 'add', '0', '0', 'conviction-date').click()
+    offenceConvictionDatePage.continueButton().click()
+
+    // RASS-1214 bug fix tested by this - previously an error message was being shown
+    Page.verifyOnPageTitle(OffenceEditOffencePage, 'offence')
   })
 })

--- a/server/routes/offenceRoutes.ts
+++ b/server/routes/offenceRoutes.ts
@@ -1488,6 +1488,7 @@ export default class OffenceRoutes extends BaseRoutes {
     const { submitToEditOffence, invalidatedFrom } = req.query
     const submitQuery = this.queryParametersToString(submitToEditOffence, invalidatedFrom)
     const offenceConvictionDateForm = trimForm<OffenceConvictionDateForm>(req.body)
+
     const errors = this.offenceService.setConvictionDateForm(
       req.session,
       nomsId,
@@ -1496,6 +1497,7 @@ export default class OffenceRoutes extends BaseRoutes {
       offenceConvictionDateForm,
       addOrEditCourtAppearance,
       this.courtAppearanceService.getWarrantDate(req.session, nomsId),
+      structuredClone(this.getSessionOffenceOrAppearanceOffence(req, nomsId, courtCaseReference, offenceReference)),
     )
     if (errors.length > 0) {
       req.flash('errors', errors)

--- a/server/services/offenceService.ts
+++ b/server/services/offenceService.ts
@@ -685,6 +685,7 @@ export default class OffenceService {
     offenceConvictionDateForm: OffenceConvictionDateForm,
     addOrEditCourtAppearance: string,
     warrantDate: Date,
+    offence: Offence,
   ): {
     text?: string
     html?: string
@@ -728,7 +729,6 @@ export default class OffenceService {
         day: offenceConvictionDateForm['convictionDate-day'],
       })
       const id = this.getOffenceId(nomsId, courtCaseReference)
-      const offence = this.getOffence(session.offences, id)
       const sentence = this.getSentence(offence, offenceReference)
 
       if (addOrEditCourtAppearance === 'add-court-appearance') {
@@ -764,6 +764,7 @@ export default class OffenceService {
       }
 
       sentence.convictionDate = convictionDate.toDate()
+      // eslint-disable-next-line no-param-reassign
       offence.sentence = sentence
       // eslint-disable-next-line no-param-reassign
       session.offences[id] = offence


### PR DESCRIPTION
Scenario for the issue:

1. Create sentencing appearance 
2. Set individual offence conviction date and go to check your answers (still in session)
3. Edit offence level conviction date and change (or dont!)

At this point the 'conviction date must be after offence start date' validation rule would fire
Reason being that the offence wasnt set in the session object being used. So switched to passing in the offence from the router and using the `getSessionOffenceOrAppearanceOffence` method because there are two sources for session offences by the looks of it 