### PR TITLE
Removing temp override fix for previous Cyprus vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1433,9 +1433,9 @@
       "peer": true
     },
     "node_modules/@cypress/request": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.0.tgz",
-      "integrity": "sha512-wGTQfwDMMMiz/muFw4YbCLwTh0uZsXKK+6zWBzftADpitSi6iM62C8GzEhNcng2srUiGPksOriQkA8zakW2R0g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.1.tgz",
+      "integrity": "sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1452,7 +1452,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.14.1",
+        "qs": "^6.15.2",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -118,17 +118,5 @@
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.9",
     "typescript": "^5.9.3"
-  },
-  "//": [
-    "Overriding qs for cypress to fix moderate (CVE-2026-8723) without breaking cypress. Remove when cypress updates their dependency to a non-vulnerable version of qs.",
-    "Overriding tmp for cypress to fix high (CVE-2026-44705) without breaking cypress. Remove when cypress updates their dependency to a non-vulnerable version of tmp."
-  ],
-  "overrides": {
-    "cypress": {
-      "@cypress/request": {
-        "qs": "^6.15.2"
-      },
-      "tmp": "0.2.6"
-    }
   }
 }


### PR DESCRIPTION
The cyprus dependencies have since been updated and no longer requires the override